### PR TITLE
Restrict msgs

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -42,7 +42,7 @@ var requestMap = make(map[string]AuthRequestData)
 
 // GenerateAuthRequest generates a new authentication request and returns it as a JSON object
 func GenerateAuthRequest(userID int64, params storage.VerificationParams) ([]byte, error) {
-	rURL := "https://ed4c-212-55-90-5.ngrok-free.app" // Updatesd with your actual URL
+	rURL := "https://d88f-109-72-122-36.ngrok-free.app" // Updatesd with your actual URL
 	sessionID := "1"                                     // Use unique session IDs in production
 	//sessionID := strconv.Itoa(int(time.Now().UnixNano()))
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -42,16 +42,16 @@ var requestMap = make(map[string]AuthRequestData)
 
 // GenerateAuthRequest generates a new authentication request and returns it as a JSON object
 func GenerateAuthRequest(userID int64, params storage.VerificationParams) ([]byte, error) {
-	rURL := "https://1705-212-55-90-5.ngrok-free.app" // Updatesd with your actual URL
+	rURL := "https://ed4c-212-55-90-5.ngrok-free.app" // Updatesd with your actual URL
 	// sessionID := 1                                     // Use unique session IDs in production
-	sessionID := int(time.Now().UnixNano())
+	sessionID := strconv.Itoa(int(time.Now().UnixNano()))
 
 	log.Println("Session ID in Generate Auth Request:", sessionID)
 	CallbackURL := "/api/callback"
 	Audience := "did:polygonid:polygon:amoy:2qQ68JkRcf3xrHPQPWZei3YeVzHPP58wYNxx2mEouR"
 
 	// Forming a URI for callback
-	uri := fmt.Sprintf("%s%s?sessionId=%s", rURL, CallbackURL, strconv.Itoa(sessionID))
+	uri := fmt.Sprintf("%s%s?sessionId=%s", rURL, CallbackURL, sessionID)
 
 	log.Println("URI:", uri)
 
@@ -84,7 +84,7 @@ func GenerateAuthRequest(userID int64, params storage.VerificationParams) ([]byt
 	// Store auth request in map associated with session ID
 	// requestMap[strconv.Itoa(sessionID)] = request
 
-	requestMap[strconv.Itoa(sessionID)] = AuthRequestData{
+	requestMap[sessionID] = AuthRequestData{
         Request: request,
         UserID:  userID,
     }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -42,7 +42,7 @@ var requestMap = make(map[string]AuthRequestData)
 
 // GenerateAuthRequest generates a new authentication request and returns it as a JSON object
 func GenerateAuthRequest(userID int64, params storage.VerificationParams) ([]byte, error) {
-	rURL := "https://5c86-109-72-122-36.ngrok-free.app" // Updatesd with your actual URL
+	rURL := "https://1705-212-55-90-5.ngrok-free.app" // Updatesd with your actual URL
 	// sessionID := 1                                     // Use unique session IDs in production
 	sessionID := int(time.Now().UnixNano())
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
+	//"strconv"
 	"time"
 
 	"github.com/ArtemHvozdov/tg-auth-bot/storage"
@@ -43,8 +43,8 @@ var requestMap = make(map[string]AuthRequestData)
 // GenerateAuthRequest generates a new authentication request and returns it as a JSON object
 func GenerateAuthRequest(userID int64, params storage.VerificationParams) ([]byte, error) {
 	rURL := "https://ed4c-212-55-90-5.ngrok-free.app" // Updatesd with your actual URL
-	// sessionID := 1                                     // Use unique session IDs in production
-	sessionID := strconv.Itoa(int(time.Now().UnixNano()))
+	sessionID := "1"                                     // Use unique session IDs in production
+	//sessionID := strconv.Itoa(int(time.Now().UnixNano()))
 
 	log.Println("Session ID in Generate Auth Request:", sessionID)
 	CallbackURL := "/api/callback"

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -30,7 +30,7 @@ func StartBot(cfg config.Config) error {
 
 	//Bot.Use(AdminOnlyMiddleware(Bot))
 
-	// Установка доступных команд
+	// Setting up commands
 	err = bot.SetCommands([]telebot.Command{
 		{Text: "start", Description: "Launch bot"},
 		{Text: "verify", Description: "Go through verification"},
@@ -146,7 +146,7 @@ func AdminOnlyMiddleware(bot *telebot.Bot) telebot.MiddlewareFunc {
                 }
             }
 
-            // Пропускаем управление следующему обработчику
+			// Pass control to the next handler
             return next(c)
         }
     }

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -1,5 +1,5 @@
 package bot
-
+ 
 import (
 	"fmt"
 	"log"
@@ -28,7 +28,7 @@ func StartBot(cfg config.Config) error {
 		return fmt.Errorf("error creating bot: %v", err)
 	}
 
-	Bot.Use(AdminOnlyMiddleware(Bot))
+	//Bot.Use(AdminOnlyMiddleware(Bot))
 
 	// Установка доступных команд
 	err = Bot.SetCommands([]telebot.Command{
@@ -51,7 +51,8 @@ func StartBot(cfg config.Config) error {
 	Bot.Handle("/setup", handlers.SetupHandler(Bot))
 	Bot.Handle("/verify", handlers.VerifyHandler(Bot))
 	Bot.Handle("/check_admin", handlers.CheckAdminHandler(Bot))
-	
+	//Bot.Handle(telebot.OnText ,handlers.MessageHandler(Bot))
+
 	// bot.Handle(telebot.OnText, handlers.TextMessageHandler(bot))
 
 	log.Println("Bot started...")

--- a/bot/bot.go
+++ b/bot/bot.go
@@ -51,9 +51,7 @@ func StartBot(cfg config.Config) error {
 	bot.Handle("/setup", handlers.SetupHandler(bot))
 	bot.Handle("/verify", handlers.VerifyHandler(bot))
 	bot.Handle("/check_admin", handlers.CheckAdminHandler(bot))
-	//Bot.Handle(telebot.OnText ,handlers.MessageHandler(Bot))
-
-	// bot.Handle(telebot.OnText, handlers.TextMessageHandler(bot))
+	
 	messageTypes := []string{
 		telebot.OnText,
 		telebot.OnPhoto,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,6 +10,7 @@ type UserVerification struct {
 	IsPending bool
 	Verified  bool
 	SessionID int64
+	RestrictStatus bool
 }
 
 var (

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -94,3 +94,24 @@ type VerificationParams struct {
 
 // Struct paramets: ID Group - auth parametrs
 var VerificationParamsMap = make(map[int64]VerificationParams)
+
+// Admin User ID - Group ID
+var GroupSetupState = make(map[int64]int64)
+
+func AddAdminUser(userID, groupID int64) {
+	DataMutex.Lock()
+	defer DataMutex.Unlock()
+
+	GroupSetupState[userID] = groupID
+}
+
+func GetIdGroupFromGroupSetapState(userID int64) int64 {
+	DataMutex.Lock()
+	defer DataMutex.Unlock()
+
+	groupID, exists := GroupSetupState[userID]
+	if !exists {
+		return 0
+	}
+	return groupID
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -115,3 +115,25 @@ func GetIdGroupFromGroupSetapState(userID int64) int64 {
 	}
 	return groupID
 }
+
+// RestrictionType - type of restriction
+// ID Chat Group -> Restriction Type ( block | delete )
+var RestrictionType = make(map[int64]string)
+
+func AddRestrictionType(groupID int64, restrictionType string) {
+	DataMutex.Lock()
+	defer DataMutex.Unlock()
+
+	RestrictionType[groupID] = restrictionType
+}
+
+func GetRestrictionType(groupID int64) string {
+	DataMutex.Lock()
+	defer DataMutex.Unlock()
+
+	restrictionType, exists := RestrictionType[groupID]
+	if !exists {
+		return ""
+	}
+	return restrictionType
+}


### PR DESCRIPTION
Added a choice of restrictions for new group members who have not yet passed verification.

1) Members are prohibited from sending messages to the group
2) Members can send any messages to the group, but the messages are immediately deleted

After passing verification, new members can send any messages to the group

Fixed the function that responds to a call to a bot command in a group from members who are not administrators. The bot does not respond to such commands and after 1 second deletes the message with the command from the group